### PR TITLE
Fix bug where git-ps pull was hiding rebase err

### DIFF
--- a/Sources/GitPatchStackCore/GitShell.swift
+++ b/Sources/GitPatchStackCore/GitShell.swift
@@ -77,10 +77,19 @@ public class GitShell {
 
     public func rebase(onto: String, from: String, to: String, interactive: Bool = false) throws {
         if interactive {
+            // Note: We don't need to handle explicit error output here because
+            // this replaces the process and therefore all standard out and error
+            // output will naturally endup in the shell.
             replaceProcess(self.path, command: "git", arguments: ["rebase", "-i", "--onto", onto, from, to])
         } else {
             let result = try run(self.path, arguments: ["rebase", "--onto", onto, from, to])
             guard result.isSuccessful else {
+                if let output = result.standardOutput, !output.isEmpty {
+                    print(output)
+                }
+                if let errOutput = result.standardError, !errOutput.isEmpty {
+                    print(errOutput)
+                }
                 throw Error.gitRebaseFailure
             }
         }


### PR DESCRIPTION
When you would do a git-ps pull it was not outputing the errors from the
rebase command. Which would leave you hanging when a conflict arose.

This takes and outputs the standard out as well as the standard error
when present resolving this issue.

This resolve issue #9.

ps-id: 054BCADE-09BF-4719-A78D-CF8512380587