### PR TITLE
Add help message when InvalidArgumentCount Exception is thrown.

### DIFF
--- a/Sources/git-ps/main.swift
+++ b/Sources/git-ps/main.swift
@@ -4,6 +4,9 @@ let gitPatchStack = try! GitPatchStack()
 
 do {
     try gitPatchStack.run()
+} catch GitPatchStack.Error.invalidArgumentCount {
+    print("Default commands are: \n\n git-ps (ls, show <patch-index>, pull, rebase, rr <patch-index>, pub <patch-index>, --version).")
 } catch {
     print("Whoops! An error occurred: \(error)")
 }
+


### PR DESCRIPTION
Help message shows valid commands.

ps-id: BF5B7C18-F51A-4B09-B889-886D5062D9AC