### PR TITLE
Fixes a strange range creation class

### DIFF
--- a/Sources/GitPatchStackCore/GitPatchStack.swift
+++ b/Sources/GitPatchStackCore/GitPatchStack.swift
@@ -363,7 +363,9 @@ public final class GitPatchStack {
         let message = try self.git.commitMessageOf(ref: patch.sha)
         let pattern = #"ps-id:\s(?<patchStackId>[\w\d-]+)"#
         let regex = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
-        if let match = regex.firstMatch(in: message, options: [], range: NSRange(location: 0, length: message.utf8.count)) {
+        let nsrange = NSRange(message.startIndex..<message.endIndex,
+        in: message)
+        if let match = regex.firstMatch(in: message, options: [], range: nsrange) {
             if let patchStackIdRange = Range(match.range(withName: "patchStackId"), in: message) {
                 let patchStackIdStr = String(message[patchStackIdRange])
                 return UUID(uuidString: patchStackIdStr)


### PR DESCRIPTION
This implements a safer way to fetch the range

[changelog]
fixed: Fixes a crash with creating an NSRange to fetch the patch-stack id

ps-id: 859BC9EA-E54F-4E6F-BB91-87EF8750496F