### PR TITLE
Add sha logging for review branch

### DIFF
--- a/Sources/GitPatchStackCore/GitPatchStack.swift
+++ b/Sources/GitPatchStackCore/GitPatchStack.swift
@@ -392,7 +392,8 @@ public final class GitPatchStack {
 
         // checkout the new branch
         try self.git.checkout(ref: branchName)
-        print("- checked out \(branchName)")
+        let currentSha = try self.git.getShaOf(ref: branchName)
+        print("- checked out \(branchName) at \(currentSha)")
 
         do {
             print("- cherry picking commit - \(commitRef)")


### PR DESCRIPTION
I did this because I'd often have to go to github to see what sha the
branch was made on so I could use it in packages in swift. This saves me
a step and prints out the sha for the branch that was just checked out.

[changelog]
added: logging for the request review branch sha-1

ps-id: E8E4C2E4-FEEF-46D5-A68C-8F6EEFB029E2