### PR TITLE
Add sha logging for review branch

### DIFF
--- a/Sources/GitPatchStackCore/GitPatchStack.swift
+++ b/Sources/GitPatchStackCore/GitPatchStack.swift
@@ -398,7 +398,8 @@ public final class GitPatchStack {
             print("- cherry picking commit - \(commitRef)")
             // cherry pick selected commit sha into branch
             try self.git.cherryPick(ref: commitRef)
-            print("- successfully cherry picked commit - \(commitRef)")
+            let branchSha = try self.git.getRevParse(ref: branchName)
+            print("- successfully cherry picked commit - \(commitRef) to \(branchSha)")
         } catch GitShell.Error.gitCherryPickFailure {
             print("Looks like you are trying to request review of a patch that conflicts with \(self.remoteBase). It could be that it is dependent on another patch that is NOT currently in \(self.remoteBase) or just be conflicting with recent changes to \(self.remoteBase).  Dependent patches MUST be in \(self.remoteBase) before requesting review of patches that depend on them.\n")
 

--- a/Sources/GitPatchStackCore/GitShell.swift
+++ b/Sources/GitPatchStackCore/GitShell.swift
@@ -113,6 +113,7 @@ public class GitShell {
         case gitCheckedOutBranchFailure
         case gitCreateAndCheckoutFailure
         case gitCherryPickCommitsFailure
+        case gitRevParseFailure
         case gitShaOfFailure
         case gitCommitMessageOfFailure
         case gitCommitAmendMessages
@@ -288,6 +289,19 @@ public class GitShell {
             }
             throw Error.gitCherryPickAbortFailure
         }
+    }
+
+    public func getRevParse(ref: String) throws -> String {
+        let result = try run(self.path, arguments: ["rev-parse", ref])
+        guard result.isSuccessful == true else {
+            throw Error.gitRevParseFailure
+        }
+
+        guard let output = result.standardOutput else {
+            throw Error.gitRevParseFailure
+        }
+
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     public func getShaOf(ref: String) throws -> String {


### PR DESCRIPTION
I did this because I'd often have to go to github to see what sha the
branch was made on so I could use it in packages in swift. This saves me
a step and prints out the sha for the branch that was just checked out.

[changelog]
added: logging for the request review branch sha-1

ps-id: E8E4C2E4-FEEF-46D5-A68C-8F6EEFB029E2

Testing

Switch to HEAD

use branchname

Move the print

Move it to existing log