### PR TITLE
Add function to parse checkout subcommand

### DIFF
--- a/Sources/GitPatchStackCore/ParseArgs.swift
+++ b/Sources/GitPatchStackCore/ParseArgs.swift
@@ -67,6 +67,21 @@ func parseShowSubcommand(_ args: ArraySlice<Substring>) -> (patchIndex: Int, opt
     return showSubcommand.run(&vArgs)
 }
 
+enum CheckoutOption: Equatable {
+    case help
+}
+
+func parseCheckoutSubcommand(_ args: ArraySlice<Substring>) -> (patchIndex: Int, options: [CheckoutOption])? {
+    let checkoutHelpOption: Parser<ArraySlice<Substring>, CheckoutOption> = .oneOf(.first("-h"), .first("--help")).map { .help }
+
+    let checkoutOptions: Parser<ArraySlice<Substring>, [CheckoutOption]> = .oneOf(checkoutHelpOption).zeroOrMore()
+
+    let checkoutSubcommand: Parser<ArraySlice<Substring>, (patchIndex: Int, options: [CheckoutOption])> = zip(checkoutOptions, patchIndex, checkoutOptions).map { opts1, patchIndex, opts2 in (patchIndex: patchIndex, options: opts1 + opts2) }
+
+    var vArgs = args
+    return checkoutSubcommand.run(&vArgs)
+}
+
 enum RequestReviewOption: Equatable {
     case branch(name: String)
     case help


### PR DESCRIPTION
So that we can use it to implement the `git ps co <patch-index>` command
in the future.

This relates to issue #40.

ps-id: B374A98F-A195-4B45-8E0F-36CEF855380A