### PR TITLE
Add getShowNoColor(ref:) to GitShell

### DIFF
--- a/Sources/GitPatchStackCore/GitShell.swift
+++ b/Sources/GitPatchStackCore/GitShell.swift
@@ -134,6 +134,7 @@ public class GitShell {
         case gitLogFailure
         case gitFetchFailure
         case gitRebaseFailure
+        case gitGetShowNoColor
         case gitUncommittedChangePresentFailure
         case gitCheckedOutBranchFailure
         case gitCreateAndCheckoutFailure
@@ -208,6 +209,19 @@ public class GitShell {
             return Commits(formattedGitLogOutput: output)
         }
         return Commits(formattedGitLogOutput: "")
+    }
+
+    public func getShowNoColor(ref: String) throws -> String {
+        let result = try run(self.path, arguments: ["show", "--no-color", "--pretty=raw", ref], currentWorkingDirectory: self.currentWorkingDirectory)
+        guard result.isSuccessful == true else {
+            throw Error.gitGetShowNoColor
+        }
+
+        guard let output = result.standardOutput else {
+            throw Error.gitGetShowNoColor
+        }
+
+        return output
     }
 
     public func diffPatch(ref: String) throws -> String {


### PR DESCRIPTION
So that we can use it in the future to implement a better `rr+`
change tracking solution.

The idea is that we will compute a sha of the output of
getShowNoColor(ref:) after stripping out lines that start with `parent
`, `commit `, `tree `, or `index `.  This should give us a hash value we
can store when request for review happens and that we can recompute and
compare against that stored hash value to detect if the content of the
patch or the attributes other than tree or parent have changed. Mapping
this to the `rr+` indicator should result in a much more meaningful &
useful `rr+`.

ps-id: E27A224A-B330-4213-BA77-B63079E69FDA