### PR TITLE
Record branch assoc in rr after success

### DIFF
--- a/Sources/GitPatchStackCore/GitPatchStack.swift
+++ b/Sources/GitPatchStackCore/GitPatchStack.swift
@@ -265,15 +265,15 @@ public final class GitPatchStack {
             let postAddIdPatchInfo = try getPatchInfo(forRange: patchIndexRange)
             let endPatchInfo = postAddIdPatchInfo.last!
 
-            let record = RequestReviewRecord(patchStackID: startPatchInfo!.patchId, branchName: branchName, commitID: startPatchInfo!.patch.hash, published: false, locationAgnosticHash: self.getLocationAgnosticHash(ref: startPatchInfo!.patch.hash))
-            try rrRepository.record(record)
-            print("- recorded patch id, branch name, and commit sha association in request review state repository")
-
             try self.createOrUpdateRequestReviewBranch(named: branchName, fromCommit: startPatchInfo!.patch.parentHash, toCommit: endPatchInfo.patch.hash, fallbackBranchName: originalBranch)
 
             // push branch up to remote
             try self.git.forcePush(branch: branchName, upToRemote: upstreamBranch.remote, displayOutput: true)
             print("- force pushed \(branchName) up to \(upstreamBranch.remote)")
+
+            let record = RequestReviewRecord(patchStackID: startPatchInfo!.patchId, branchName: branchName, commitID: startPatchInfo!.patch.hash, published: false, locationAgnosticHash: self.getLocationAgnosticHash(ref: startPatchInfo!.patch.hash))
+            try rrRepository.record(record)
+            print("- recorded patch id, branch name, and commit sha association in request review state repository")
 
             // checkout original branch
             try self.git.checkout(ref: originalBranch)
@@ -291,19 +291,19 @@ public final class GitPatchStack {
                 return requestReviewRecord.branchName
             })
 
-            let matchPatchInfo = patchInfo.first { (patch: Commit, patchId: UUID?) in
-                patchId == requestReviewRecord.patchStackID
-            }
-            let record = RequestReviewRecord(patchStackID: requestReviewRecord.patchStackID, branchName: branchName, commitID: matchPatchInfo!.patch.hash, published: false, locationAgnosticHash: self.getLocationAgnosticHash(ref: matchPatchInfo!.patch.hash))
-            try rrRepository.record(record)
-            print("- recorded patch id, branch name, and commit sha association in request review state repository")
-
             let endPatchInfo = patchInfo.last!
             try self.createOrUpdateRequestReviewBranch(named: branchName, fromCommit: origStartPatchInfo.patch.parentHash, toCommit: endPatchInfo.patch.hash, fallbackBranchName: originalBranch)
 
             // push branch up to remote
             try self.git.forcePush(branch: branchName, upToRemote: upstreamBranch.remote, displayOutput: true)
             print("- force pushed \(branchName) up to \(upstreamBranch.remote)")
+
+            let matchPatchInfo = patchInfo.first { (patch: Commit, patchId: UUID?) in
+                patchId == requestReviewRecord.patchStackID
+            }
+            let record = RequestReviewRecord(patchStackID: requestReviewRecord.patchStackID, branchName: branchName, commitID: matchPatchInfo!.patch.hash, published: false, locationAgnosticHash: self.getLocationAgnosticHash(ref: matchPatchInfo!.patch.hash))
+            try rrRepository.record(record)
+            print("- recorded patch id, branch name, and commit sha association in request review state repository")
 
             // checkout original branch
             try self.git.checkout(ref: originalBranch)
@@ -382,15 +382,15 @@ public final class GitPatchStack {
                 return
             }
 
-            let record = RequestReviewRecord(patchStackID: uuid, branchName: rrBranch, commitID: patch.sha, published: false, locationAgnosticHash: self.getLocationAgnosticHash(ref: patch.sha))
-            try rrRepository.record(record)
-            print("- recorded patch id, branch name, and commit sha association in request review state repository")
-
             try self.createOrUpdateRequestReviewBranch(named: rrBranch, withCommit: patch.sha, fallbackBranchName: originalBranch)
 
             // push branch up to remote
             try self.git.forcePush(branch: rrBranch, upToRemote: upstreamBranch.remote, displayOutput: true)
             print("- force pushed \(rrBranch) up to \(upstreamBranch.remote)")
+
+            let record = RequestReviewRecord(patchStackID: uuid, branchName: rrBranch, commitID: patch.sha, published: false, locationAgnosticHash: self.getLocationAgnosticHash(ref: patch.sha))
+            try rrRepository.record(record)
+            print("- recorded patch id, branch name, and commit sha association in request review state repository")
 
             // checkout original branch
             try self.git.checkout(ref: originalBranch)
@@ -415,15 +415,15 @@ public final class GitPatchStack {
                 return
             }
 
-            let record = RequestReviewRecord(patchStackID: newPatchID, branchName: rrBranch, commitID: newPatch.sha, published: false, locationAgnosticHash: self.getLocationAgnosticHash(ref: newPatch.sha))
-            try rrRepository.record(record)
-            print("- recorded patch id, branch name, and commit sha association in request review state repository")
-
             try self.createOrUpdateRequestReviewBranch(named: rrBranch, withCommit: newPatch.sha, fallbackBranchName: originalBranch)
 
             // push branch up to remote
             try self.git.forcePush(branch: rrBranch, upToRemote: upstreamBranch.remote, displayOutput: true)
             print("- force pushed \(rrBranch) up to \(upstreamBranch.remote)")
+
+            let record = RequestReviewRecord(patchStackID: newPatchID, branchName: rrBranch, commitID: newPatch.sha, published: false, locationAgnosticHash: self.getLocationAgnosticHash(ref: newPatch.sha))
+            try rrRepository.record(record)
+            print("- recorded patch id, branch name, and commit sha association in request review state repository")
 
             // checkout original branch
             try self.git.checkout(ref: originalBranch)


### PR DESCRIPTION
I changed this behavior so that if when the user attempts to request
review (rr) of a patch or a series of patches and has it fail to create
the rr branch, cherry pick the path(es) into that branch, or push that
branch up to the remote it will no longer record the association of the
the branch.

Technically this has the risk of leaving unused ps/rr/ branches behind
in the scenario where a user request review for a patch without specify
an explicit branch name in which it fails & then the user requests
review for that same patch with an explicit branch name. It is worth
noting that nothing currently will go back and clean that branch up
because nothing knows about the association of that branch to any other
concept.

This edge case is acceptable in my eyes at least for the time being as I
suspect this edge case is pretty rare that it will happen. Also it isn't
a major problem people leave branches around all the time and don't
bother to clean them up for ages. Also it is safe for people to clean
them up as they normally would with git.

So I still feel like this is an improvement for the user experience as a
whole and think we should make this changes.

This relates to issue #16.

[changelog]
fixed: bug where rr status would appear even when rr failed

ps-id: F2AC601A-5A66-4F4E-A424-A41A3AB934ED